### PR TITLE
Fixed test for new yii2

### DIFF
--- a/tests/unit/RobotsTxtTest.php
+++ b/tests/unit/RobotsTxtTest.php
@@ -27,6 +27,7 @@ class RobotsTxtTest extends \Codeception\TestCase\Test
     public function testRobotsTxtHostHttps()
     {
         $_SERVER['HTTPS'] = 'on';
+        $_SERVER['SERVER_PORT'] = 443;
         $robotstxt = new RobotsTxt();
         $this->assertEquals('https://www.example.com', $robotstxt->host);
         $this->assertEquals("Host: https://www.example.com\n", $robotstxt->render());


### PR DESCRIPTION
У меня начал ломаться тест, кажется из-за смены логики определения порта в методе getHostInfo() в последней версии Yii2. Если эту строчку убрать, то будет такая ошибка:
Failed asserting that two strings are equal.
Expected :'https://www.example.com'
Actual   :'https://www.example.com:80'